### PR TITLE
GetMapSize causes a null reference when we have no IBpfMap

### DIFF
--- a/service/src/com/android/server/BpfNetMaps.java
+++ b/service/src/com/android/server/BpfNetMaps.java
@@ -1007,8 +1007,10 @@ public class BpfNetMaps {
         // deletion. netd and skDestroyListener could delete CookieTagMap entry concurrently.
         // So using Set to count the number of entry in the map.
         Set<K> keySet = new ArraySet<>();
-        map.forEach((k, v) -> keySet.add(k));
-        return keySet.size();
+        if (sEnableJavaBpfMap) {
+            map.forEach((k, v) -> keySet.add(k)); 
+        }
+        return keySet.size();       
     }
 
     /** Callback for StatsManager#setPullAtomCallback */


### PR DESCRIPTION
```02-11 23:05:38.766  1693  3120 E AndroidRuntime: *** FATAL EXCEPTION IN SYSTEM PROCESS: android.net.connectivity.com.android.modules.utils.BackgroundThread
02-11 23:05:38.766  1693  3120 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke interface method 'void android.net.connectivity.com.android.net.module.util.IBpfMap.forEach(android.net.connectivity.com.android.net.module.util.IBpfMap$ThrowingBiConsumer)' on a null object reference
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.net.connectivity.com.android.server.BpfNetMaps.getMapSize(BpfNetMaps.java:1010)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.net.connectivity.com.android.server.BpfNetMaps.pullBpfMapInfoAtom(BpfNetMaps.java:1023)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.net.connectivity.com.android.server.BpfNetMaps$$ExternalSyntheticLambda3.onPullAtom(R8$$SyntheticClass:0)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.app.StatsManager$PullAtomCallbackInternal.lambda$onPullAtom$0(StatsManager.java:688)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.app.StatsManager$PullAtomCallbackInternal.$r8$lambda$wkAbOHvoKcxNXFVeEyQU5e9coiY(Unknown Source:0)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.app.StatsManager$PullAtomCallbackInternal$$ExternalSyntheticLambda0.run(Unknown Source:6)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:958)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:99)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:205)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:294)
02-11 23:05:38.766  1693  3120 E AndroidRuntime:        at android.os.HandlerThread.run(HandlerThread.java:67)```